### PR TITLE
When rendering a node with null content, a TypeError is thrown

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,7 @@ export class EL {
       this.content = new TEXT(this.content);
     }
 
-    if (!Array.isArray(this.content)) {
+    if (null != content && !Array.isArray(this.content)) {
       this.content = [this.content];
     }
 

--- a/tests/charata.test.js
+++ b/tests/charata.test.js
@@ -41,4 +41,13 @@ describe('charata', () => {
     assert.ok(myUl.length === 1);
     assert.ok(myLIs.length === 3);
   });
+
+  it('should render elements with no children nor text', () => {
+    el('div', null).renderTo(document.body);
+
+    let myDiv = document.getElementsByTagName('div');
+
+    assert.strictEqual(myDiv.length, 1);
+    assert.strictEqual(myDiv[0].innerHTML, '');
+  });
 });


### PR DESCRIPTION
The null content gets wrapped in an array, and when rendering, it fails, trying to call `null.render()`:

```
1) charata should render elements with no children nor text:
     TypeError: 'null' is not an object (evaluating 'c.render')
```

A test case and a fix are provided in the PR.
